### PR TITLE
chore(python): set minimum python version to 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Follow this [guide](https://github.com/factset/enterprise-sdk#authentication) to
 
 ### Python
 
-1. Install and activate python 3.6+. If you're using [pyenv](https://github.com/pyenv/pyenv):
+1. Install and activate python 3.7+. If you're using [pyenv](https://github.com/pyenv/pyenv):
 
    ```sh
    pyenv install 3.9.7

--- a/python/Basic/ApiKey/pyproject.toml
+++ b/python/Basic/ApiKey/pyproject.toml
@@ -5,9 +5,9 @@ description = "Basic ApiKey Example"
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
-"fds.sdk.utils" = "^0.9.0"
-"fds.sdk.PAEngine" = "^0.9.0"
+python = "^3.7"
+"fds.sdk.utils" = "^1.0.0"
+"fds.sdk.PAEngine" = "^0.20.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/python/Basic/Oauth/pyproject.toml
+++ b/python/Basic/Oauth/pyproject.toml
@@ -5,9 +5,9 @@ description = "Basic OAuth Example"
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
-"fds.sdk.utils" = "^0.9.0"
-"fds.sdk.PAEngine" = "^0.9.0"
+python = "^3.7"
+"fds.sdk.utils" = "^1.0.0"
+"fds.sdk.PAEngine" = "^0.20.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/python/PAEngine/pyproject.toml
+++ b/python/PAEngine/pyproject.toml
@@ -5,9 +5,9 @@ description = "PAEngine Example"
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
-"fds.sdk.utils" = "^0.9.0"
-"fds.sdk.PAEngine" = "^0.9.0"
+python = "^3.7"
+"fds.sdk.utils" = "^1.0.0"
+"fds.sdk.PAEngine" = "^0.20.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Python 3.6 has reached EOL (https://devguide.python.org/devcycle/#end-of-life-branches). Rising minimum Python version to 3.7