### PR TITLE
chore(nodejs): set minimum Node.js version to 14.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,21 @@ Follow this [guide](https://github.com/factset/enterprise-sdk#authentication) to
 
 ### TypeScript
 
-1. [Install Yarn](https://classic.yarnpkg.com/lang/en/docs/install). If you're using the terminal:
+1. [Download and install](https://nodejs.org/en/download/) Node.js 14.19 or greater
+
+2. [Install Yarn](https://classic.yarnpkg.com/lang/en/docs/install). If you're using the terminal:
 
    ```sh
    npm install --global yarn
    ```
 
-2. Move to the directory containing the sample you wish to run (e.g. `cd typescript/PAEngine`). Install depenencies.
+3. Move to the directory containing the sample you wish to run (e.g. `cd typescript/PAEngine`). Install depenencies.
 
    ```sh
    yarn install
    ```
 
-3. Run the sample. Make any necessary changes to the sample code (e.g. the OAuth 2.0 configuration file path) and run it:
+4. Run the sample. Make any necessary changes to the sample code (e.g. the OAuth 2.0 configuration file path) and run it:
 
    ```sh
    yarn start

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Follow this [guide](https://github.com/factset/enterprise-sdk#authentication) to
 
 ### TypeScript
 
-1. [Download and install](https://nodejs.org/en/download/) Node.js 14.19 or greater
+1. [Download and install](https://nodejs.org/en/download/) Node.js 14.19 or greater.
 
 2. [Install Yarn](https://classic.yarnpkg.com/lang/en/docs/install). If you're using the terminal:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Follow this [guide](https://github.com/factset/enterprise-sdk#authentication) to
    npm install --global yarn
    ```
 
-3. Move to the directory containing the sample you wish to run (e.g. `cd typescript/PAEngine`). Install depenencies.
+3. Move to the directory containing the sample you wish to run (e.g. `cd typescript/PAEngine`). Install dependencies.
 
    ```sh
    yarn install

--- a/typescript/Basic/ApiKey/package.json
+++ b/typescript/Basic/ApiKey/package.json
@@ -8,13 +8,16 @@
   "author": "FactSet Research Systems",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^17.0.15",
-    "ts-node": "^10.4.0",
-    "typescript": "^4.5.5"
+    "@types/node": "^17.0.40",
+    "ts-node": "^10.8.1",
+    "typescript": "^4.7.3"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.2",
-    "@factset/sdk-paengine": "0.9.0",
-    "@factset/sdk-utils": "^0.9.0"
+    "@babel/runtime": "^7.18.3",
+    "@factset/sdk-paengine": "^0.20.0",
+    "@factset/sdk-utils": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=14.19.0"
   }
 }

--- a/typescript/Basic/OAuth/package.json
+++ b/typescript/Basic/OAuth/package.json
@@ -8,13 +8,16 @@
   "author": "FactSet Research Systems",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^17.0.15",
-    "ts-node": "^10.4.0",
-    "typescript": "^4.5.5"
+    "@types/node": "^17.0.40",
+    "ts-node": "^10.8.1",
+    "typescript": "^4.7.3"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.2",
-    "@factset/sdk-paengine": "0.9.0",
-    "@factset/sdk-utils": "^0.9.0"
+    "@babel/runtime": "^7.18.3",
+    "@factset/sdk-paengine": "^0.20.0",
+    "@factset/sdk-utils": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=14.19.0"
   }
 }

--- a/typescript/PAEngine/package.json
+++ b/typescript/PAEngine/package.json
@@ -8,13 +8,16 @@
   "author": "FactSet Research Systems",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^17.0.15",
-    "ts-node": "^10.4.0",
-    "typescript": "^4.5.5"
+    "@types/node": "^17.0.40",
+    "ts-node": "^10.8.1",
+    "typescript": "^4.7.3"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.2",
-    "@factset/sdk-paengine": "0.9.0",
-    "@factset/sdk-utils": "^0.9.0"
+    "@babel/runtime": "^7.18.3",
+    "@factset/sdk-paengine": "^0.20.0",
+    "@factset/sdk-utils": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=14.19.0"
   }
 }


### PR DESCRIPTION
Node.js 12 has reached EOL (https://nodejs.org/en/about/releases/). Rising minimum Node.js version to 14.19